### PR TITLE
Compile on stable and cargo clippy --fix

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,5 +15,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --verbose
+    - name: Build Web
+      run: cargo build --target wasm32-unknown-unknown --verbose
     - name: Run tests
       run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ derive_more = "0.99"
 once_cell = "1.2"
 instant = { version = "0.1", features = [ "wasm-bindgen", ] }
 serde = { version = "1.0", features = [ "derive", ] }
+num-traits = "0.2.11"
 
 # fs
 dirs-next = "1.0"

--- a/examples/3d.rs
+++ b/examples/3d.rs
@@ -1,7 +1,5 @@
 // wengwengweng
 
-#![feature(clamp)]
-
 use dirty::*;
 use math::*;
 use geom::*;
@@ -114,7 +112,7 @@ impl State for Game {
 					rx += delta.x * self.eye_speed * 0.0001;
 					ry += delta.y * self.eye_speed * 0.0001;
 
-					ry = ry.clamp(-dead, dead);
+					ry = num_traits::(ry, -dead, dead);
 
 					self.cam.set_angle(rx, ry);
 

--- a/examples/audio.rs
+++ b/examples/audio.rs
@@ -17,10 +17,10 @@ impl State for Game {
 		let sound = Sound::from_bytes(d.audio, include_bytes!("res/shoot.ogg"))?;
 		let track = Track::from_bytes(d.audio, include_bytes!("res/yo.ogg"))?;
 
-		return Ok(Self {
-			sound: sound,
-			track: track,
-		});
+		Ok(Self {
+			sound,
+			track,
+		})
 
 	}
 
@@ -51,7 +51,7 @@ impl State for Game {
 			_ => {},
 		}
 
-		return Ok(());
+		Ok(())
 
 	}
 
@@ -85,7 +85,7 @@ impl State for Game {
 			d.gfx.draw(&shapes::text("playing").size(16.0))?;
 		}
 
-		return Ok(());
+		Ok(())
 
 	}
 

--- a/examples/audio.rs
+++ b/examples/audio.rs
@@ -39,7 +39,11 @@ impl State for Game {
 							self.track.pause();
 						}
 					},
-					_ => self.sound.play(),
+					_ => self.sound
+						.builder()
+						.pan(math::rand(-1.0, 1.0))
+						.play()
+						,
 				}
 			},
 			_ => {},

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -13,10 +13,10 @@ struct Game {
 impl State for Game {
 
 	fn init(d: &mut Ctx) -> Result<Self> {
-		return Ok(Self {
+		Ok(Self {
 			tex: gfx::Texture::from_bytes(d.gfx, include_bytes!("res/bunny.png"))?,
 			count: 10000,
-		});
+		})
 	}
 
 	fn event(&mut self, d: &mut Ctx, e: &input::Event) -> Result<()> {
@@ -34,7 +34,7 @@ impl State for Game {
 			_ => {},
 		}
 
-		return Ok(());
+		Ok(())
 
 	}
 
@@ -42,7 +42,7 @@ impl State for Game {
 
 		d.window.set_title(&format!("FPS: {} DCS: {} OBJS: {}", d.app.fps(), d.gfx.draw_calls(), self.count));
 
-		return Ok(());
+		Ok(())
 
 	}
 
@@ -83,7 +83,7 @@ impl State for Game {
 			&shapes::text(&format!("{} bunnies", self.count)),
 		)?;
 
-		return Ok(());
+		Ok(())
 
 	}
 

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -13,9 +13,9 @@ struct Game {
 impl State for Game {
 
 	fn init(_: &mut Ctx) -> Result<Self> {
-		return Ok(Self {
+		Ok(Self {
 			events: VecDeque::with_capacity(24),
-		});
+		})
 	}
 
 	fn event(&mut self, d: &mut Ctx, e: &input::Event) -> Result<()> {
@@ -38,7 +38,7 @@ impl State for Game {
 			_ => {},
 		}
 
-		return Ok(());
+		Ok(())
 
 	}
 
@@ -66,7 +66,7 @@ impl State for Game {
 
 		}
 
-		return Ok(());
+		Ok(())
 
 	}
 

--- a/examples/mviewer.rs
+++ b/examples/mviewer.rs
@@ -2,8 +2,6 @@
 
 // TODO: handle load failure
 
-#![feature(clamp)]
-
 use std::path::Path;
 
 use dirty::*;
@@ -115,7 +113,7 @@ impl State for Viewer {
 						let orig_scale = 480.0 / size;
 
 						self.scale -= s.y * (1.0 / size);
-						self.scale = self.scale.clamp(orig_scale * 0.1, orig_scale * 3.2);
+						self.scale = num_traits::clamp(self.scale, orig_scale * 0.1, orig_scale * 3.2);
 
 					}
 

--- a/examples/noise.rs
+++ b/examples/noise.rs
@@ -47,14 +47,14 @@ impl Game {
 		let seed = self.seed as u32;
 
 		let noise: Box<dyn NoiseFn<[f64; 2]>> = match self.noise_type {
-			NoiseType::Perlin => box Perlin::new().set_seed(seed),
-			NoiseType::OpenSimplex => box OpenSimplex::new().set_seed(seed),
-			NoiseType::SuperSimplex => box SuperSimplex::new().set_seed(seed),
-			NoiseType::Fbm => box Fbm::new().set_seed(seed),
-			NoiseType::Billow => box Billow::new().set_seed(seed),
-			NoiseType::Worley => box Worley::new().enable_range(true).set_seed(seed),
-			NoiseType::RidgedMulti => box RidgedMulti::new().set_seed(seed),
-			NoiseType::Turbulence => box Turbulence::new(Fbm::new()).set_seed(seed),
+			NoiseType::Perlin => Box::new(Perlin::new().set_seed(seed)),
+			NoiseType::OpenSimplex => Box::new(OpenSimplex::new().set_seed(seed)),
+			NoiseType::SuperSimplex => Box::new(SuperSimplex::new().set_seed(seed)),
+			NoiseType::Fbm => Box::new(Fbm::new().set_seed(seed)),
+			NoiseType::Billow => Box::new(Billow::new().set_seed(seed)),
+			NoiseType::Worley => Box::new(Worley::new().enable_range(true).set_seed(seed)),
+			NoiseType::RidgedMulti => Box::new(RidgedMulti::new().set_seed(seed)),
+			NoiseType::Turbulence => Box::new(Turbulence::new(Fbm::new()).set_seed(seed)),
 		};
 
 		let w = ctx.width() as i32;

--- a/examples/raw.rs
+++ b/examples/raw.rs
@@ -9,7 +9,7 @@ struct Game;
 impl State for Game {
 
 	fn init(_: &mut Ctx) -> Result<Self> {
-		return Ok(Self);
+		Ok(Self)
 	}
 
 	fn event(&mut self, d: &mut Ctx, e: &input::Event) -> Result<()> {
@@ -26,7 +26,7 @@ impl State for Game {
 			_ => {},
 		}
 
-		return Ok(());
+		Ok(())
 
 	}
 
@@ -55,7 +55,7 @@ impl State for Game {
 			},
 		], &[0, 1, 2]))?;
 
-		return Ok(());
+		Ok(())
 
 	}
 

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -29,10 +29,10 @@ struct Game {
 impl State for Game {
 
 	fn init(d: &mut Ctx) -> Result<Self> {
-		return Ok(Self {
+		Ok(Self {
 			rainbow_shader: gfx::Shader::from_frag(d.gfx, include_str!("res/rainbow.frag"))?,
 			model: gfx::Model::from_glb(d.gfx, include_bytes!("res/duck.glb"))?,
-		});
+		})
 	}
 
 	fn event(&mut self, d: &mut Ctx, e: &input::Event) -> Result<()> {
@@ -49,7 +49,7 @@ impl State for Game {
 			_ => {},
 		}
 
-		return Ok(());
+		Ok(())
 
 	}
 
@@ -73,11 +73,11 @@ impl State for Game {
 					,
 			)?;
 
-			return Ok(());
+			Ok(())
 
 		})?;
 
-		return Ok(());
+		Ok(())
 
 	}
 

--- a/examples/sprite.rs
+++ b/examples/sprite.rs
@@ -19,9 +19,9 @@ impl State for Game {
 		sprite.add_anim("run", 0, 3, true);
 		sprite.play("run");
 
-		return Ok(Self {
-			sprite: sprite,
-		});
+		Ok(Self {
+			sprite,
+		})
 
 	}
 
@@ -40,7 +40,7 @@ impl State for Game {
 			_ => {},
 		}
 
-		return Ok(());
+		Ok(())
 
 	}
 
@@ -49,7 +49,7 @@ impl State for Game {
 		d.window.set_title(&format!("FPS: {} DCS: {}", d.app.fps(), d.gfx.draw_calls()));
 		self.sprite.update(d.app.dt());
 
-		return Ok(());
+		Ok(())
 
 	}
 
@@ -57,7 +57,7 @@ impl State for Game {
 
 		d.gfx.draw(&self.sprite)?;
 
-		return Ok(());
+		Ok(())
 
 	}
 

--- a/examples/squiggly_line.rs
+++ b/examples/squiggly_line.rs
@@ -1,0 +1,137 @@
+// wengwengweng
+
+use dirty::*;
+use dirty::math::*;
+use gfx::shapes;
+use input::Key;
+
+struct Polyline {
+	line: Vec<Vec2>,
+}
+
+impl Polyline {
+	fn new(line: Vec<Vec2>) -> Self {
+		Self {
+			line,
+		}
+	}
+
+	fn push(&mut self, p: Vec2) {
+		self.line.push(p);
+	}
+
+	fn clear(&mut self) {
+		self.line.clear();
+	}
+
+	fn draw(&self, d: &mut Ctx) -> Result<()> {
+		for (p0, p1) in self.line.iter().zip(self.line.iter().skip(1)) {
+			d.gfx.draw(
+				&shapes::line(*p0, *p1)
+					.width(2.0)
+					// .color()
+			)?
+		}
+		Ok(())
+	}
+}
+
+struct Squiggly {
+	frames: Vec<Polyline>,
+}
+
+impl Squiggly {
+	fn new(buf: &Polyline, n: usize, tol: usize) -> Self {
+		let mut frames = vec![];
+		for _ in 0..n {
+			let frame = buf.line.iter()
+				.map(|&v| v + vec2!(rand(0,tol), rand(0,tol)))
+				.collect::<Vec<_>>();
+			frames.push(Polyline::new(frame));
+		}
+		Self {
+			frames,
+		}
+	}
+
+	fn draw(&self, t: usize, d: &mut Ctx) -> Result<()> {
+		let f = &self.frames[t % self.frames.len()];
+		f.draw(d)?;
+		Ok(())
+	}
+}
+
+struct Game {
+	key_down: bool,
+	lines: Vec<Squiggly>,
+	buf: Polyline,
+	t: usize,
+}
+
+impl State for Game {
+
+	fn init(_: &mut Ctx) -> Result<Self> {
+		Ok(Self {
+			key_down: false,
+			lines: vec![],
+			buf: Polyline::new(vec![]),
+			t: 0,
+		})
+	}
+
+	fn update(&mut self, _: &mut Ctx) -> Result<()> {
+		self.t += 1;
+		self.t %= 60;
+		Ok(())
+	}
+
+	fn event(&mut self, d: &mut Ctx, e: &input::Event) -> Result<()> {
+		use input::Event::*;
+
+		match e {
+			MousePress(_) => {
+				self.key_down = true;
+			}
+			MouseRelease(_) => {
+				self.key_down = false;
+				self.lines.push(Squiggly::new(&self.buf, 10, 3));
+				self.buf.clear();
+			}
+			MouseMove(_) => {
+				let pos = d.window.mouse_pos();
+				if self.key_down {
+					self.buf.push(pos);
+				}
+			}
+			KeyPress(k) => {
+				match *k {
+					Key::Esc => d.window.quit(),
+					_ => {},
+				}
+			},
+			_ => {},
+		}
+
+		Ok(())
+
+	}
+
+	fn draw(&mut self, d: &mut Ctx) -> Result<()> {
+		self.buf.draw(d)?;
+		for line in &self.lines {
+			line.draw(self.t, d)?;
+		}
+
+		Ok(())
+
+	}
+
+}
+
+fn main() {
+	if let Err(err) = launcher()
+		.run::<Game>() {
+		println!("{}", err);
+	}
+}
+

--- a/examples/synth.rs
+++ b/examples/synth.rs
@@ -1,7 +1,5 @@
 // wengwengweng
 
-#![feature(clamp)]
-
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::Mutex;

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -3,7 +3,7 @@
 #![feature(box_syntax)]
 
 use dirty::*;
-use math::*;
+
 use input::Key;
 
 struct Game {
@@ -13,9 +13,9 @@ struct Game {
 impl State for Game {
 
 	fn init(_: &mut Ctx) -> Result<Self> {
-		return Ok(Self {
+		Ok(Self {
 			ui: ui::UI::new(),
-		});
+		})
 	}
 
 	fn event(&mut self, d: &mut Ctx, e: &input::Event) -> Result<()> {
@@ -34,7 +34,7 @@ impl State for Game {
 			_ => {},
 		}
 
-		return Ok(());
+		Ok(())
 
 	}
 
@@ -52,11 +52,11 @@ impl State for Game {
 			p.sep(ctx)?;
 			p.button(ctx, "explode")?;
 
-			return Ok(());
+			Ok(())
 
 		})?;
 
-		return Ok(());
+		Ok(())
 
 	}
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,6 @@
 
 use std::time::Duration;
 use instant::Instant;
-use crate::*;
 
 /// Provides Information to the Application Lifecycle
 pub struct App {

--- a/src/audio/buffer.rs
+++ b/src/audio/buffer.rs
@@ -16,7 +16,7 @@ impl Buffered {
 	pub fn new(src: impl Source) -> Self {
 		return Self {
 			sample_rate: src.sample_rate(),
-			buf: Arc::new(src.into_iter().collect()),
+			buf: Arc::new(src.collect()),
 			cur_idx: 0,
 		};
 	}
@@ -28,7 +28,7 @@ impl Buffered {
 impl Iterator for Buffered {
 	type Item = Frame;
 	fn next(&mut self) -> Option<Self::Item> {
-		let v = self.buf.get(self.cur_idx).map(|f| *f);
+		let v = self.buf.get(self.cur_idx).copied();
 		self.cur_idx += 1;
 		return v;
 	}

--- a/src/audio/decoder.rs
+++ b/src/audio/decoder.rs
@@ -27,7 +27,7 @@ impl<R: Read + Seek> Decoder<R> {
 			return Ok(Self::Mp3(Mp3Decoder::new(reader)?));
 		}
 
-		return Err(format!("failed to decode audio"));
+		return Err("failed to decode audio".to_string());
 
 	}
 

--- a/src/audio/effect.rs
+++ b/src/audio/effect.rs
@@ -1,0 +1,29 @@
+// wengwengweng
+
+use super::*;
+
+pub trait Effect {
+	fn frame(&mut self, _: Frame) -> Frame;
+}
+
+#[derive(Clone)]
+pub struct Volume(pub f32);
+
+impl Effect for Volume {
+	fn frame(&mut self, (left, right): Frame) -> Frame {
+		return (left * self.0, right * self.0);
+	}
+}
+
+#[derive(Clone)]
+pub struct Pan(pub f32);
+
+impl Effect for Pan {
+	fn frame(&mut self, (left, right): Frame) -> Frame {
+		return (
+			left * self.0.map(1.0, -1.0, 0.0, 2.0),
+			right * self.0.map(-1.0, 1.0, 0.0, 2.0),
+		);
+	}
+}
+

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -18,6 +18,7 @@ import!(decoder);
 import!(buffer);
 export!(source);
 export!(types);
+export!(effect);
 
 #[cfg(not(web))]
 export!(track);

--- a/src/audio/mp3.rs
+++ b/src/audio/mp3.rs
@@ -66,11 +66,11 @@ pub fn is_mp3<R: Read + Seek>(mut data: R) -> bool {
 	let mut decoder = puremp3::Mp3Decoder::new(data.by_ref());
 
 	if decoder.next_frame().is_err() {
-		data.seek(SeekFrom::Start(pos));
+		data.seek(SeekFrom::Start(pos)).expect("cannot seek to start");
 		return false;
 	}
 
-	data.seek(SeekFrom::Start(pos));
+	data.seek(SeekFrom::Start(pos)).expect("cannot seek to start");
 
 	return true;
 

--- a/src/audio/mp3.rs
+++ b/src/audio/mp3.rs
@@ -20,15 +20,15 @@ impl<R: Read + Seek> Mp3Decoder<R> {
 		let mut decoder = puremp3::Mp3Decoder::new(data);
 		let cur_frame = decoder
 			.next_frame()
-			.map_err(|_| format!("failed to parse mp3"))?;
+			.map_err(|_| "failed to parse mp3".to_string())?;
 		let header = &cur_frame.header;
 		let sample_rate = header.sample_rate.hz();
 
 		return Ok(Self {
-			decoder: decoder,
-			cur_frame: cur_frame,
+			decoder,
+			cur_frame,
 			cur_frame_offset: 0,
-			sample_rate: sample_rate,
+			sample_rate,
 		});
 
 	}
@@ -39,7 +39,7 @@ impl<R: Read + Seek> Mp3Decoder<R> {
 
 		reader
 			.seek(SeekFrom::Start(0))
-			.map_err(|_| format!("failed to seek mp3"))?;
+			.map_err(|_| "failed to seek mp3".to_string())?;
 
 		self.cur_frame_offset = 0;
 
@@ -84,14 +84,14 @@ pub fn is_mp3<R: Read + Seek>(mut reader: R) -> Result<bool> {
 
 	let pos = reader
 		.seek(SeekFrom::Current(0))
-		.map_err(|_| format!("failed to seek"))?;
+		.map_err(|_| "failed to seek".to_string())?;
 
 	let mut decoder = puremp3::Mp3Decoder::new(&mut reader);
 	let is_mp3 = decoder.next_frame().is_ok();
 
 	reader
 		.seek(SeekFrom::Start(pos))
-		.map_err(|_| format!("failed to seek"))?;
+		.map_err(|_| "failed to seek".to_string())?;
 
 	return Ok(is_mp3);
 

--- a/src/audio/native.rs
+++ b/src/audio/native.rs
@@ -24,11 +24,11 @@ impl Audio {
 
 		let device = host
 			.default_output_device()
-			.ok_or(format!("failed to get default output device"))?;
+			.ok_or("failed to get default output device".to_string())?;
 
 		let format = device
 			.default_output_format()
-			.map_err(|_| format!("failed to get default audio output format"))?;
+			.map_err(|_| "failed to get default audio output format".to_string())?;
 
 		let format = cpal::Format {
 			channels: CHANNEL_COUNT.to_cpal(),
@@ -39,11 +39,11 @@ impl Audio {
 		let event_loop = host.event_loop();
 		let stream_id = event_loop
 			.build_output_stream(&device, &format)
-			.map_err(|_| format!("failed to build audio output stream"))?;
+			.map_err(|_| "failed to build audio output stream".to_string())?;
 
 		event_loop
-			.play_stream(stream_id.clone())
-			.map_err(|_| format!("failed to start audio stream"))?;
+			.play_stream(stream_id)
+			.map_err(|_| "failed to start audio stream".to_string())?;
 
 		thread::Builder::new()
 			.name(String::from("dirty_audio"))
@@ -100,10 +100,10 @@ impl Audio {
 
 			});
 
-		}).map_err(|_| format!("failed to spawn audio thread"))?;
+		}).map_err(|_| "failed to spawn audio thread".to_string())?;
 
 		return Ok(Self {
-			mixer: mixer,
+			mixer,
 		});
 
 	}

--- a/src/audio/sound.rs
+++ b/src/audio/sound.rs
@@ -22,7 +22,7 @@ impl Sound {
 		let buffer = Buffered::new(Decoder::new(Cursor::new(data.to_owned()))?);
 
 		return Ok(Self {
-			buffer: buffer,
+			buffer,
 			mixer: Arc::clone(ctx.mixer()),
 		});
 

--- a/src/audio/sound.rs
+++ b/src/audio/sound.rs
@@ -59,11 +59,11 @@ impl<'a> SoundBuilder<'a> {
 		self.effects.push(Arc::new(Mutex::new(e)));
 		return self;
 	}
-	pub fn pan(mut self, p: f32) -> Self {
-		return self.add(Pan(p));
+	pub fn pan(self, p: f32) -> Self {
+		self.add(Pan(p))
 	}
-	pub fn volume(mut self, v: f32) -> Self {
-		return self.add(Volume(v));
+	pub fn volume(self, v: f32) -> Self {
+		self.add(Volume(v))
 	}
 	pub fn play(self) {
 		if let Ok(mut mixer) = self.mixer.lock() {

--- a/src/audio/source.rs
+++ b/src/audio/source.rs
@@ -2,5 +2,5 @@
 
 use super::*;
 
-pub trait Source: Iterator<Item = Frame> {}
+pub trait Source: Iterator<Item=Frame> {}
 

--- a/src/audio/synth/basic.rs
+++ b/src/audio/synth/basic.rs
@@ -36,7 +36,7 @@ impl BasicSynth {
 	}
 
 	pub fn set_volume(&mut self, v: f32) {
-		self.volume = v.clamp(0.0, 1.0);
+		self.volume = num_traits::clamp(v, 0.0, 1.0);
 	}
 
 	pub fn play(&mut self, v: Voice) {

--- a/src/audio/track.rs
+++ b/src/audio/track.rs
@@ -29,24 +29,24 @@ impl Track {
 
 		let mut mixer = ctx.mixer()
 			.lock()
-			.map_err(|_| format!("failed to get mixer"))?;
+			.map_err(|_| "failed to get mixer".to_string())?;
 
 		let id = mixer.add(src.clone());
 
 		let control = mixer
 			.get_control(&id)
-			.ok_or(format!("failed to get mixer"))?;
+			.ok_or("failed to get mixer".to_string())?;
 
 		mixer.add_effect(&id, volume.clone());
 		mixer.add_effect(&id, pan.clone());
 		control.set_paused(true);
 
 		return Ok(Self {
-			src: src,
-			id: id,
-			control: control,
-			volume: volume,
-			pan: pan,
+			src,
+			id,
+			control,
+			volume,
+			pan,
 		});
 
 	}

--- a/src/audio/vorbis.rs
+++ b/src/audio/vorbis.rs
@@ -22,7 +22,7 @@ impl<R: Read + Seek> VorbisDecoder<R> {
 	pub fn new(reader: R) -> Result<Self> {
 
 		let mut decoder = OggStreamReader::new(reader)
-			.map_err(|_| format!("failed to parse vorbis"))?;
+			.map_err(|_| "failed to parse vorbis".to_string())?;
 
 		let header = &decoder.ident_hdr;
 
@@ -36,14 +36,14 @@ impl<R: Read + Seek> VorbisDecoder<R> {
 
 		let data = match decoder.read_dec_packet_generic::<InterleavedSamples<f32>>() {
 			Ok(data) => data,
-			Err(e) => return Err(format!("failed to read vorbis")),
+			Err(e) => return Err("failed to read vorbis".to_string()),
 		};
 
 		return Ok(Self {
-			decoder: decoder,
+			decoder,
 			cur_packet: data.map(|d| d.samples.into_iter()),
-			channel_count: channel_count,
-			sample_rate: sample_rate,
+			channel_count,
+			sample_rate,
 		});
 
 	}
@@ -72,7 +72,7 @@ impl<R: Read + Seek> VorbisDecoder<R> {
 		self.decoder
 			// TODO: not working
 			.seek_absgp_pg(0)
-			.map_err(|_| format!("failed to seek vorbis"))?;
+			.map_err(|_| "failed to seek vorbis".to_string())?;
 		self.cur_packet = self.decoder
 			.read_dec_packet_generic::<InterleavedSamples<f32>>()
 			.ok()
@@ -113,13 +113,13 @@ pub fn is_vorbis<R: Read + Seek>(mut reader: R) -> Result<bool> {
 
 	let pos = reader
 		.seek(SeekFrom::Current(0))
-		.map_err(|_| format!("failed to seek"))?;
+		.map_err(|_| "failed to seek".to_string())?;
 
 	let is_vorbis = OggStreamReader::new(&mut reader).is_ok();
 
 	reader
 		.seek(SeekFrom::Start(pos))
-		.map_err(|_| format!("failed to seek"))?;
+		.map_err(|_| "failed to seek".to_string())?;
 
 	return Ok(is_vorbis)
 

--- a/src/audio/vorbis.rs
+++ b/src/audio/vorbis.rs
@@ -96,11 +96,11 @@ pub fn is_vorbis<R: Read + Seek>(mut data: R) -> bool {
 	};
 
 	if OggStreamReader::new(data.by_ref()).is_err() {
-		data.seek(SeekFrom::Start(pos));
+		data.seek(SeekFrom::Start(pos)).expect("cannot seek to start");
 		return false;
 	}
 
-	data.seek(SeekFrom::Start(pos));
+	data.seek(SeekFrom::Start(pos)).expect("cannot seek to start");
 
 	return true;
 

--- a/src/audio/wav.rs
+++ b/src/audio/wav.rs
@@ -18,7 +18,7 @@ impl<R: Read + Seek> WavDecoder<R> {
 
 	pub fn new(data: R) -> Result<Self> {
 
-		let wav = hound::WavReader::new(data).map_err(|_| format!("failed to parse wav"))?;
+		let wav = hound::WavReader::new(data).map_err(|_| "failed to parse wav".to_string())?;
 		let spec = wav.spec();
 
 		let channel_count = match spec.channels {
@@ -30,10 +30,10 @@ impl<R: Read + Seek> WavDecoder<R> {
 		let duration = Duration::from_secs_f32(wav.duration() as f32 / spec.sample_rate as f32);
 
 		return Ok(Self {
-			spec: spec,
+			spec,
 			decoder: wav,
-			duration: duration,
-			channel_count: channel_count,
+			duration,
+			channel_count,
 		});
 
 	}
@@ -57,7 +57,7 @@ impl<R: Read + Seek> WavDecoder<R> {
 	pub fn reset(&mut self) -> Result<()> {
 		self.decoder
 			.seek(0)
-			.map_err(|_| format!("failed to seek wav"))?;
+			.map_err(|_| "failed to seek wav".to_string())?;
 		return Ok(());
 	}
 
@@ -93,13 +93,13 @@ pub fn is_wav<R: Read + Seek>(mut reader: R) -> Result<bool> {
 
 	let pos = reader
 		.seek(SeekFrom::Current(0))
-		.map_err(|_| format!("failed to seek"))?;
+		.map_err(|_| "failed to seek".to_string())?;
 
 	let is_wav = hound::WavReader::new(&mut reader).is_ok();
 
 	reader
 		.seek(SeekFrom::Start(pos))
-		.map_err(|_| format!("failed to seek"))?;
+		.map_err(|_| "failed to seek".to_string())?;
 
 	return Ok(is_wav);
 

--- a/src/audio/wav.rs
+++ b/src/audio/wav.rs
@@ -88,11 +88,11 @@ pub fn is_wav<R: Read + Seek>(mut data: R) -> bool {
 	};
 
 	if hound::WavReader::new(data.by_ref()).is_err() {
-		data.seek(SeekFrom::Start(pos));
+		data.seek(SeekFrom::Start(pos)).expect("cannot seek to start");
 		return false;
 	}
 
-	data.seek(SeekFrom::Start(pos));
+	data.seek(SeekFrom::Start(pos)).expect("cannot seek to start");
 
 	return true;
 

--- a/src/audio/web.rs
+++ b/src/audio/web.rs
@@ -39,9 +39,9 @@ impl Sound {
 		let abuf = Rc::new(RefCell::new(None));
 		let abuf2 = abuf.clone();
 
-		let handler = Closure::wrap(box (move |b: web_sys::AudioBuffer| {
+		let handler = Closure::wrap(Box::new((move |b: web_sys::AudioBuffer| {
 			*abuf2.borrow_mut() = Some(b);
-		}) as Box<dyn FnMut(_)>);
+		})) as Box<dyn FnMut(_)>);
 
 		ctx.ctx
 			.decode_audio_data_with_success_callback(&buf.buffer(), handler.as_ref().unchecked_ref())

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -34,8 +34,8 @@ impl Conf {
 	pub fn basic(title: &str, width: i32, height: i32) -> Self {
 		return Self {
 			title: String::from(title),
-			width: width,
-			height: height,
+			width,
+			height,
 			..Default::default()
 		};
 	}

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -79,7 +79,7 @@ pub fn exists(path: impl AsRef<Path>) -> bool {
 /// get files that matches a glob pattern (e.g. `glob("img/*.png")`)
 pub fn glob(pat: &str) -> Result<Vec<PathBuf>> {
 
-	let listings = glob::glob(&format!("{}", pat))
+	let listings = glob::glob(&pat.to_string())
 		.ok()
 		.or_else(|| glob::glob(&format!("{}/{}", res_dir()?.display(), pat)).ok())
 		.ok_or(format!("failed to execute glob pattern {}", pat))?

--- a/src/geom/meshgen.rs
+++ b/src/geom/meshgen.rs
@@ -31,29 +31,29 @@ pub fn uv_quad(cols: usize, rows: usize) -> MeshData {
 
 			verts.push(Vertex {
 				pos: vec3!(x, y + gh, 0) - vec3!(0.5, 0.5, 0),
-				color: color,
-				normal: normal,
+				color,
+				normal,
 				uv: vec2!(x, y),
 			});
 
 			verts.push(Vertex {
 				pos: vec3!(x + gw, y + gh, 0) - vec3!(0.5, 0.5, 0),
-				color: color,
-				normal: normal,
+				color,
+				normal,
 				uv: vec2!(x + gw, y),
 			});
 
 			verts.push(Vertex {
 				pos: vec3!(x + gw, y, 0) - vec3!(0.5, 0.5, 0),
-				color: color,
-				normal: normal,
+				color,
+				normal,
 				uv: vec2!(x + gw, y + gh),
 			});
 
 			verts.push(Vertex {
 				pos: vec3!(x, y, 0) - vec3!(0.5, 0.5, 0),
-				color: color,
-				normal: normal,
+				color,
+				normal,
 				uv: vec2!(x, y + gh),
 			});
 
@@ -63,7 +63,7 @@ pub fn uv_quad(cols: usize, rows: usize) -> MeshData {
 
 	return MeshData {
 		vertices: verts,
-		indices: indices,
+		indices,
 	};
 
 }
@@ -114,7 +114,7 @@ pub fn sphere(r: f32) -> MeshData {
 
 	return MeshData {
 		vertices: verts,
-		indices: indices,
+		indices,
 	};
 
 }
@@ -159,7 +159,7 @@ pub fn cylinder(r: f32, h: f32, s: usize) -> MeshData {
 
 	let circle = MeshData {
 		vertices: verts,
-		indices: indices,
+		indices,
 	};
 
 	return ops::extrude(&circle, &edges, h);
@@ -174,7 +174,7 @@ pub fn torus(r1: f32, r2: f32) -> MeshData {
 
 	return MeshData {
 		vertices: verts,
-		indices: indices,
+		indices,
 	};
 
 }
@@ -207,28 +207,28 @@ pub fn checkerboard(s: f32, c: usize, r: usize) -> MeshData {
 			verts.push(Vertex {
 				pos: pt + vec3!(0),
 				normal: vec3!(0, 1, 0),
-				color: color,
+				color,
 				uv: vec2!(0, 0),
 			});
 
 			verts.push(Vertex {
 				pos: pt + vec3!(s, 0, 0),
 				normal: vec3!(0, 1, 0),
-				color: color,
+				color,
 				uv: vec2!(0, 0),
 			});
 
 			verts.push(Vertex {
 				pos: pt + vec3!(s, 0, s),
 				normal: vec3!(0, 1, 0),
-				color: color,
+				color,
 				uv: vec2!(0, 0),
 			});
 
 			verts.push(Vertex {
 				pos: pt + vec3!(0, 0, s),
 				normal: vec3!(0, 1, 0),
-				color: color,
+				color,
 				uv: vec2!(0, 0),
 			});
 
@@ -253,7 +253,7 @@ pub fn checkerboard(s: f32, c: usize, r: usize) -> MeshData {
 
 	return MeshData {
 		vertices: verts,
-		indices: indices,
+		indices,
 	};
 
 }

--- a/src/geom/meshgen.rs
+++ b/src/geom/meshgen.rs
@@ -109,8 +109,8 @@ pub fn cube(s: f32) -> MeshData {
 // TODO
 pub fn sphere(r: f32) -> MeshData {
 
-	let mut verts = vec![];
-	let mut indices = vec![];
+	let verts = vec![];
+	let indices = vec![];
 
 	return MeshData {
 		vertices: verts,
@@ -169,8 +169,8 @@ pub fn cylinder(r: f32, h: f32, s: usize) -> MeshData {
 // TODO
 pub fn torus(r1: f32, r2: f32) -> MeshData {
 
-	let mut verts = vec![];
-	let mut indices = vec![];
+	let verts = vec![];
+	let indices = vec![];
 
 	return MeshData {
 		vertices: verts,

--- a/src/geom/ops.rs
+++ b/src/geom/ops.rs
@@ -36,7 +36,7 @@ pub fn extrude(data: &MeshData, edges: &[(u32, u32)], dis: f32) -> MeshData {
 
 	return MeshData {
 		vertices: verts,
-		indices: indices,
+		indices,
 	};
 
 }

--- a/src/geom/types.rs
+++ b/src/geom/types.rs
@@ -15,8 +15,8 @@ impl Ray3 {
 
 	pub const fn new(origin: Vec3, dir: Vec3) -> Self {
 		return Self {
-			origin: origin,
-			dir: dir,
+			origin,
+			dir,
 		};
 	}
 
@@ -36,8 +36,8 @@ impl Ray2 {
 
 	pub const fn new(origin: Vec2, dir: Vec2) -> Self {
 		return Self {
-			origin: origin,
-			dir: dir,
+			origin,
+			dir,
 		};
 	}
 
@@ -56,8 +56,8 @@ pub struct Line2 {
 impl Line2 {
 	pub const fn new(p1: Vec2, p2: Vec2) -> Self {
 		return Self {
-			p1: p1,
-			p2: p2,
+			p1,
+			p2,
 		};
 	}
 }
@@ -71,8 +71,8 @@ pub struct Line3 {
 impl Line3 {
 	pub const fn new(p1: Vec3, p2: Vec3) -> Self {
 		return Self {
-			p1: p1,
-			p2: p2,
+			p1,
+			p2,
 		};
 	}
 }
@@ -87,8 +87,8 @@ impl Rect {
 
 	pub const fn new(min: Vec2, max: Vec2) -> Self {
 		return Self {
-			min: min,
-			max: max,
+			min,
+			max,
 		};
 	}
 
@@ -116,8 +116,8 @@ impl BBox {
 
 	pub const fn new(min: Vec3, max: Vec3) -> Self {
 		return Self {
-			min: min,
-			max: max,
+			min,
+			max,
 		};
 	}
 
@@ -235,8 +235,8 @@ impl Plane {
 
 	pub const fn new(normal: Vec3, dist: f32) -> Self {
 		return Self {
-			normal: normal,
-			dist: dist,
+			normal,
+			dist,
 		};
 	}
 	pub fn from_pts(p0: Vec3, p1: Vec3, p2: Vec3) -> Self {
@@ -260,8 +260,8 @@ impl Circle {
 
 	pub const fn new(center: Vec2, radius: f32) -> Self {
 		return Self {
-			center: center,
-			radius: radius,
+			center,
+			radius,
 		};
 	}
 
@@ -286,8 +286,8 @@ impl Sphere {
 
 	pub const fn new(center: Vec3, radius: f32) -> Self {
 		return Self {
-			center: center,
-			radius: radius,
+			center,
+			radius,
 		};
 	}
 

--- a/src/gfx.rs
+++ b/src/gfx.rs
@@ -252,7 +252,7 @@ impl Gfx {
 	pub fn draw_on(&mut self, canvas: &Canvas, f: impl FnOnce(&mut Self) -> Result<()>) -> Result<()> {
 
 		if self.cur_canvas.is_some() {
-			return Err(format!("cannot use canvas inside a canvas"));
+			return Err("cannot use canvas inside a canvas".to_string());
 		}
 
 		self.flush();

--- a/src/gfx/canvas.rs
+++ b/src/gfx/canvas.rs
@@ -25,7 +25,7 @@ impl Canvas {
 
 		return Ok(Self {
 			gl_fbuf: fbuf,
-			tex: tex,
+			tex,
 			width: w,
 			height: h,
 		});

--- a/src/gfx/canvas.rs
+++ b/src/gfx/canvas.rs
@@ -4,7 +4,6 @@ use std::path::Path;
 
 use crate::*;
 use gfx::*;
-use gfx::*;
 
 #[derive(Clone, PartialEq)]
 pub struct Canvas {

--- a/src/gfx/font.rs
+++ b/src/gfx/font.rs
@@ -29,10 +29,10 @@ pub struct BitmapFontData {
 impl BitmapFontData {
 	pub const fn new(img: &'static [u8], gw: u8, gh: u8, chars: &'static str) -> Self {
 		return Self {
-			img: img,
-			gw: gw,
-			gh: gh,
-			chars: chars,
+			img,
+			gw,
+			gh,
+			chars,
 		};
 	}
 }
@@ -70,7 +70,7 @@ impl BitmapFont {
 		let cols = tw / gw as i32;
 
 		if (tw % gw as i32 != 0 || th % gh as i32 != 0) {
-			return Err(format!("bitmap font grid size not correct"));
+			return Err("bitmap font grid size not correct".to_string());
 		}
 
 		for (i, ch) in chars.chars().enumerate() {
@@ -85,9 +85,9 @@ impl BitmapFont {
 		}
 
 		return Ok(Self {
-			tex: tex,
-			map: map,
-			quad_size: quad_size,
+			tex,
+			map,
+			quad_size,
 			grid_width: gw,
 			grid_height: gh,
 		});
@@ -133,15 +133,15 @@ impl TruetypeFont {
 		let tex = Texture::new(ctx, max_w, max_h)?;
 
 		if size > 72 {
-			return Err(format!("font size cannot exceed 72"));
+			return Err("font size cannot exceed 72".to_string());
 		}
 
 		return Ok(Self {
-			font: font,
-			size: size,
+			font,
+			size,
 			map: HashMap::new(),
 			cur_pt: pt!(0, 0),
-			tex: tex,
+			tex,
 		});
 
 	}
@@ -168,7 +168,7 @@ impl TruetypeFont {
 			}
 
 			if y >= th {
-				return Err(format!("reached font texture size limit"));
+				return Err("reached font texture size limit".to_string());
 			}
 
 			self.tex.sub_data(x as i32, y as i32, w as i32, self.size as i32, &nbitmap);

--- a/src/gfx/model.rs
+++ b/src/gfx/model.rs
@@ -174,8 +174,7 @@ fn read_gltf_node(bin: &[u8], nodes: &mut HashMap<usize, NodeData>, node: gltf::
 					return positions
 						.map(|v| vec3!(v[0], v[1], v[2]))
 						.collect::<Vec<Vec3>>();
-				})
-				.unwrap_or(vec![]);
+				}).unwrap_or_default();
 
 			let indices = reader
 				.read_indices()
@@ -183,8 +182,7 @@ fn read_gltf_node(bin: &[u8], nodes: &mut HashMap<usize, NodeData>, node: gltf::
 					return indices
 						.into_u32()
 						.collect::<Vec<u32>>();
-				})
-				.unwrap_or(vec![]);
+				}).unwrap_or_default();
 
 			let normals = reader
 				.read_normals()
@@ -192,8 +190,7 @@ fn read_gltf_node(bin: &[u8], nodes: &mut HashMap<usize, NodeData>, node: gltf::
 					return normals
 						.map(|v| vec3!(v[0], v[1], v[2]))
 						.collect::<Vec<Vec3>>();
-				})
-				.unwrap_or(vec![]);
+				}).unwrap_or_default();
 
 			let normals = if normals.len() != positions.len() {
 				ops::gen_normals(&positions, &indices)
@@ -209,8 +206,7 @@ fn read_gltf_node(bin: &[u8], nodes: &mut HashMap<usize, NodeData>, node: gltf::
 						// gltf/glb exported by blender uses linear color space
 						.map(|c| rgba!(c[0], c[1], c[2], c[3]).to_srgb())
 						.collect::<Vec<Color>>();
-				})
-				.unwrap_or(vec![]);
+				}).unwrap_or_default();
 
 			let texcoords = reader
 				.read_tex_coords(0)
@@ -219,8 +215,7 @@ fn read_gltf_node(bin: &[u8], nodes: &mut HashMap<usize, NodeData>, node: gltf::
 						.into_f32()
 						.map(|t| vec2!(t[0], t[1]))
 						.collect::<Vec<Vec2>>();
-				})
-				.unwrap_or(vec![]);
+				}).unwrap_or_default();
 
 			let mut verts = Vec::with_capacity(positions.len());
 
@@ -239,19 +234,19 @@ fn read_gltf_node(bin: &[u8], nodes: &mut HashMap<usize, NodeData>, node: gltf::
 
 			return MeshData {
 				vertices: verts,
-				indices: indices,
+				indices,
 			};
 
 		}).collect();
 
-	}).unwrap_or(vec![]);
+	}).unwrap_or_default();
 
 	nodes.insert(id, NodeData {
-		id: id,
+		id,
 		name: name.map(String::from),
 		children: node.children().map(|c| c.index()).collect(),
-		transform: transform,
-		meshes: meshes,
+		transform,
+		meshes,
 	});
 
 	for c in node.children() {
@@ -275,12 +270,12 @@ impl Model {
 				path.set_extension("mtl");
 
 				let mtl_src = fs::read_str(&path).ok();
-				let mtl_src = mtl_src.as_ref().map(|s| s.as_str());
+				let mtl_src = mtl_src.as_deref();
 
 				path.set_extension("png");
 
 				let img_src = fs::read(&path).ok();
-				let img_src = img_src.as_ref().map(|i| i.as_slice());
+				let img_src = img_src.as_deref();
 
 				let data = gfx::Model::load_obj(&obj_src, mtl_src, img_src)?;
 
@@ -298,7 +293,7 @@ impl Model {
 			},
 
 			_ => {
-				return Err(format!("unrecognized model"));
+				return Err("unrecognized model".to_string());
 			},
 
 		}
@@ -341,11 +336,11 @@ impl Model {
 
 		// init
 		let glb = Glb::from_slice(bytes)
-			.map_err(|_| format!("failed to parse glb"))?;
+			.map_err(|_| "failed to parse glb".to_string())?;
 		let document = Gltf::from_slice(&glb.json)
-			.map_err(|_| format!("failed to parse document from glb"))?;
+			.map_err(|_| "failed to parse document from glb".to_string())?;
 		let bin = glb.bin
-			.ok_or_else(|| format!("failed to parse bin from glb"))?;
+			.ok_or_else(|| "failed to parse bin from glb".to_string())?;
 
 		// image
 		use gltf::image::Source;
@@ -400,21 +395,21 @@ impl Model {
 
 				let frames: Vec<f32> = reader
 					.read_inputs()
-					.ok_or(format!("failed to read anim"))?
+					.ok_or("failed to read anim".to_string())?
 					.collect();
 
 				use gltf::animation::util::ReadOutputs;
 
 				match reader
 					.read_outputs()
-					.ok_or(format!("failed to read anim"))? {
+					.ok_or("failed to read anim".to_string())? {
 
 					ReadOutputs::Translations(translations) => {
 						let mut values = Vec::with_capacity(frames.len());
 						for (i, v) in translations.enumerate() {
 							let t = frames
 								.get(i)
-								.ok_or(format!("failed to read anim from glb"))?;
+								.ok_or("failed to read anim from glb".to_string())?;
 							values.push((*t, vec3!(v[0], v[1], v[2])));
 						}
 						anim.pos = values;
@@ -425,7 +420,7 @@ impl Model {
 						for (i, v) in rotations.into_f32().enumerate() {
 							let t = frames
 								.get(i)
-								.ok_or(format!("failed to read anim from glb"))?;
+								.ok_or("failed to read anim from glb".to_string())?;
 							values.push((*t, vec4!(v[0], v[1], v[2], v[3])));
 						}
 						anim.rot = values;
@@ -436,7 +431,7 @@ impl Model {
 						for (i, v) in scales.enumerate() {
 							let t = frames
 								.get(i)
-								.ok_or(format!("failed to read anim from glb"))?;
+								.ok_or("failed to read anim from glb".to_string())?;
 							values.push((*t, vec3!(v[0], v[1], v[2])));
 						}
 						anim.scale = values;
@@ -468,11 +463,11 @@ impl Model {
 		}
 
 		return Ok(ModelData {
-			nodes: nodes,
-			root_nodes: root_nodes,
-			img: img,
-			anims: anims,
-			anim_len: anim_len,
+			nodes,
+			root_nodes,
+			img,
+			anims,
+			anim_len,
 		});
 
 	}
@@ -483,7 +478,7 @@ impl Model {
 			return mtl
 				.map(|m| tobj::load_mtl_buf(&mut Cursor::new(m)))
 				.unwrap_or(Ok((vec![], hmap![])));
-		}).map_err(|_| format!("failed to parse obj"))?;
+		}).map_err(|_| "failed to parse obj".to_string())?;
 
 		let mut root_nodes = Vec::with_capacity(models.len());
 		let mut nodes = HashMap::with_capacity(models.len());
@@ -556,9 +551,9 @@ impl Model {
 		};
 
 		return Ok(ModelData {
-			nodes: nodes,
-			root_nodes: root_nodes,
-			img: img,
+			nodes,
+			root_nodes,
+			img,
 			anims: hmap![],
 			anim_len: 0.0,
 		});
@@ -590,16 +585,16 @@ impl Model {
 				name: node.name,
 				children: node.children,
 				transform: node.transform,
-				meshes: meshes,
+				meshes,
 			});
 		}).collect::<HashMap<usize, Node>>();
 
 		return Ok(Self {
 			bbox: get_bbox(&nodes, &root_nodes),
-			nodes: nodes,
-			anim_len: anim_len,
-			anims: anims,
-			root_nodes: root_nodes,
+			nodes,
+			anim_len,
+			anims,
+			root_nodes,
 			texture: tex,
 		});
 

--- a/src/gfx/model.rs
+++ b/src/gfx/model.rs
@@ -64,7 +64,7 @@ pub struct Anim {
 	scale: Track<Vec3>,
 }
 
-fn get_track_val<T: Lerpable>(track: &Track<T>, t: f32) -> Option<T> {
+fn get_track_val<T: Copy>(track: &Track<T>, t: f32) -> Option<T> {
 
 	if track.is_empty() {
 		return None;

--- a/src/gfx/shapes/circle.rs
+++ b/src/gfx/shapes/circle.rs
@@ -15,8 +15,8 @@ pub struct Circle {
 impl Circle {
 	pub fn new(center: Vec2, radius: f32) -> Self {
 		return Self {
-			center: center,
-			radius: radius,
+			center,
+			radius,
 			segments: None,
 			stroke: None,
 			fill: Some(rgba!(1)),
@@ -98,9 +98,9 @@ pub(super) fn rounded_poly_verts(verts: &[Vec2], radius: f32, segments: Option<u
 	for i in 0..len {
 
 		// TODO: subtraction overflow
-		let prev = verts.get(i - 1).map(|p| *p).unwrap_or(verts[len - 1]);
+		let prev = verts.get(i - 1).copied().unwrap_or(verts[len - 1]);
 		let p = verts[i];
-		let next = verts.get(i + 1).map(|p| *p).unwrap_or(verts[0]);
+		let next = verts.get(i + 1).copied().unwrap_or(verts[0]);
 		let angle = normalize_angle(p.angle(prev) - p.angle(next));
 		let dis = radius / f32::tan(angle / 2.0);
 
@@ -168,7 +168,7 @@ impl Drawable for Circle {
 		}
 
 		let poly = Polygon {
-			pts: pts,
+			pts,
 			fill: self.fill,
 			stroke: self.stroke.clone(),
 			radius: None,

--- a/src/gfx/shapes/gradient.rs
+++ b/src/gfx/shapes/gradient.rs
@@ -13,8 +13,8 @@ pub struct Gradient {
 impl Gradient {
 	pub fn from(p1: Vec2, p2: Vec2, steps: &[(Color, f32)]) -> Gradient {
 		return Self {
-			p1: p1,
-			p2: p2,
+			p1,
+			p2,
 			steps: steps.to_vec(),
 			width: 1.0,
 		};
@@ -34,7 +34,7 @@ impl Drawable for Gradient {
 	fn draw(&self, ctx: &mut Gfx) -> Result<()> {
 
 		if self.steps.len() < 2 {
-			return Err(format!("need at least 2 points to draw a gradient"));
+			return Err("need at least 2 points to draw a gradient".to_string());
 		}
 
 		use gfx::Vertex;
@@ -54,10 +54,8 @@ impl Drawable for Gradient {
 
 		for s in &self.steps {
 
-			if (last_pos.is_none()) {
-				if (s.1 != 0.0) {
-					return Err(format!("gradient step should start at 0.0"));
-				}
+			if (last_pos.is_none()) && (s.1 != 0.0) {
+				return Err("gradient step should start at 0.0".to_string());
 			}
 
 			last_pos = Some(s.1);
@@ -79,7 +77,7 @@ impl Drawable for Gradient {
 		}
 
 		if (last_pos != Some(1.0)) {
-			return Err(format!("gradient step should end at 1.0"));
+			return Err("gradient step should end at 1.0".to_string());
 		}
 
 		let indices = [

--- a/src/gfx/shapes/line.rs
+++ b/src/gfx/shapes/line.rs
@@ -15,8 +15,8 @@ pub struct Line {
 impl Line {
 	pub fn new(p1: Vec2, p2: Vec2) -> Self {
 		return Self {
-			p1: p1,
-			p2: p2,
+			p1,
+			p2,
 			width: 1.0,
 			color: rgba!(1),
 			cap: LineCap::Butt,
@@ -41,8 +41,8 @@ impl Line {
 	}
 	pub fn dashed(mut self, len: f32, interval: f32) -> Self {
 		self.dash = Some(LineDash {
-			len: len,
-			interval: interval,
+			len,
+			interval,
 		});
 		return self;
 	}
@@ -76,8 +76,8 @@ impl Drawable for Line {
 				}
 
 				ctx.draw(&Line {
-					p1: p1,
-					p2: p2,
+					p1,
+					p2,
 					width: self.width,
 					color: self.color,
 					cap: self.cap,

--- a/src/gfx/shapes/line3d.rs
+++ b/src/gfx/shapes/line3d.rs
@@ -17,8 +17,8 @@ pub fn line3d(p1: Vec3, p2: Vec3) -> Line3D {
 impl Line3D {
 	pub fn new(p1: Vec3, p2: Vec3) -> Self {
 		return Self {
-			p1: p1,
-			p2: p2,
+			p1,
+			p2,
 			color: rgba!(),
 			width: 1.0,
 		};

--- a/src/gfx/shapes/points.rs
+++ b/src/gfx/shapes/points.rs
@@ -19,7 +19,7 @@ pub struct Points<'a> {
 impl<'a> Points<'a> {
 	pub fn from(pts: &'a[Vec2]) -> Self {
 		return Self {
-			pts: pts,
+			pts,
 			size: 1.0,
 			color: rgba!(1),
 			mode: PointMode::Rect,

--- a/src/gfx/shapes/polygon.rs
+++ b/src/gfx/shapes/polygon.rs
@@ -94,7 +94,7 @@ impl Drawable for Polygon {
 					pos: ctx.transform * vec3!(p.x, p.y, 0.0),
 					uv: vec2!(0),
 					normal: vec3!(0, 0, 1),
-					color: color,
+					color,
 				});
 
 				if i >= 2 {

--- a/src/gfx/shapes/raw.rs
+++ b/src/gfx/shapes/raw.rs
@@ -16,8 +16,8 @@ pub struct Raw<'a> {
 impl<'a> Raw<'a> {
 	pub fn new(verts: &'a [Vertex], indices: &'a [u32]) -> Self {
 		return Self {
-			verts: verts,
-			indices: indices,
+			verts,
+			indices,
 			prim: gl::Primitive::Triangle,
 			tex: None,
 			color: rgba!(1),

--- a/src/gfx/shapes/rect.rs
+++ b/src/gfx/shapes/rect.rs
@@ -14,8 +14,8 @@ pub struct Rect {
 impl Rect {
 	pub fn from_pts(p1: Vec2, p2: Vec2) -> Self {
 		return Self {
-			p1: p1,
-			p2: p2,
+			p1,
+			p2,
 			radius: None,
 			stroke: None,
 			fill: Some(rgba!(1)),

--- a/src/gfx/shapes/rect3d.rs
+++ b/src/gfx/shapes/rect3d.rs
@@ -17,8 +17,8 @@ pub fn rect3d(p1: Vec3, p2: Vec3) -> Rect3D {
 impl Rect3D {
 	pub fn from_pts(p1: Vec3, p2: Vec3) -> Self {
 		return Self {
-			p1: p1,
-			p2: p2,
+			p1,
+			p2,
 			color: rgba!(),
 			line_width: 1.0,
 		};

--- a/src/gfx/shapes/sprite.rs
+++ b/src/gfx/shapes/sprite.rs
@@ -20,7 +20,7 @@ pub struct Sprite<'a> {
 impl<'a> Sprite<'a> {
 	pub fn new(tex: &'a gfx::Texture) -> Self {
 		return Self {
-			tex: tex,
+			tex,
 			quad: quad!(0, 0, 1, 1),
 			color: rgba!(1),
 			offset: None,

--- a/src/gfx/shapes/text.rs
+++ b/src/gfx/shapes/text.rs
@@ -63,14 +63,12 @@ impl FormattedText {
 	pub fn cursor_pos(&self, i: usize) -> Option<Vec2> {
 		if self.chars.is_empty() {
 			return Some(vec2!(0));
+		} else if i == 0 {
+			return Some(vec2!(0))
 		} else {
-			if i == 0 {
-				return Some(vec2!(0))
-			} else {
-				return self.chars.get(i - 1).map(|ch| {
-					return ch.pos + vec2!(ch.width, 0);
-				});
-			}
+			return self.chars.get(i - 1).map(|ch| {
+				return ch.pos + vec2!(ch.width, 0);
+			});
 		}
 	}
 
@@ -212,10 +210,10 @@ fn format(chunks: &[TextChunk], font: &dyn gfx::Font, conf: &FormatConf) -> Form
 					}
 
 					cur_line.chars.push(FormattedChar {
-						ch: ch,
+						ch,
 						pos: vec2!(),
 						tex: tex.clone(),
-						quad: quad,
+						quad,
 						color: chunk.color,
 						width: gw - conf.char_spacing,
 					});
@@ -278,7 +276,7 @@ fn format(chunks: &[TextChunk], font: &dyn gfx::Font, conf: &FormatConf) -> Form
 
 	return FormattedText {
 		chars: fchars,
-		scale: scale,
+		scale,
 		width: w,
 		height: h,
 		color: conf.color,

--- a/src/gfx/shapes/uvrect.rs
+++ b/src/gfx/shapes/uvrect.rs
@@ -13,8 +13,8 @@ pub struct UVRect<'a> {
 impl<'a> UVRect<'a> {
 	pub fn new(p1: Vec2, p2: Vec2) -> Self {
 		return Self {
-			p1: p1,
-			p2: p2,
+			p1,
+			p2,
 			color: rgba!(1),
 			tex: None,
 		};

--- a/src/gfx/texture.rs
+++ b/src/gfx/texture.rs
@@ -14,7 +14,7 @@ impl Texture {
 
 	pub(crate) fn from_gl_tex(gl_tex: gl::Texture2D) -> Self {
 		return Self {
-			gl_tex: gl_tex,
+			gl_tex,
 		};
 	}
 

--- a/src/gl/attr.rs
+++ b/src/gl/attr.rs
@@ -10,7 +10,7 @@ pub(super) struct VertexAttrIter<'a> {
 
 pub(super) fn iter_attrs<'a>(attrs: &'a VertexAttrGroup) -> VertexAttrIter<'a> {
 	return VertexAttrIter {
-		attrs: attrs,
+		attrs,
 		cur_offset: 0,
 		cur_idx: 0,
 	};

--- a/src/gl/batch.rs
+++ b/src/gl/batch.rs
@@ -29,8 +29,8 @@ impl<V: VertexLayout, U: UniformLayout> BatchedMesh<V, U> {
 		let ibuf = IndexBuffer::new(&device, max_indices, BufferUsage::Dynamic)?;
 
 		return Ok(Self {
-			vbuf: vbuf,
-			ibuf: ibuf,
+			vbuf,
+			ibuf,
 			vqueue: Vec::with_capacity(max_vertices),
 			iqueue: Vec::with_capacity(max_indices),
 			cur_state: None,
@@ -68,7 +68,7 @@ impl<V: VertexLayout, U: UniformLayout> BatchedMesh<V, U> {
 			self.cur_state = Some(RenderState {
 				pipeline: pipeline.clone(),
 				uniform: uniform.clone(),
-				prim: prim,
+				prim,
 			});
 		}
 

--- a/src/gl/batch.rs
+++ b/src/gl/batch.rs
@@ -3,18 +3,15 @@
 use super::*;
 use crate::Result;
 
-pub trait BatchedVertex = VertexLayout + Clone;
-pub trait BatchedUniform = UniformLayout + Clone + PartialEq;
-
 // TODO: take blending and stuff into account
 #[derive(Clone, PartialEq)]
-struct RenderState<V: BatchedVertex, U: BatchedUniform> {
+struct RenderState<V: VertexLayout, U: UniformLayout> {
 	pipeline: Pipeline<V, U>,
 	prim: Primitive,
 	uniform: U,
 }
 
-pub struct BatchedMesh<V: BatchedVertex, U: BatchedUniform> {
+pub struct BatchedMesh<V: VertexLayout, U: UniformLayout> {
 	vbuf: VertexBuffer<V>,
 	ibuf: IndexBuffer,
 	vqueue: Vec<V>,
@@ -23,7 +20,7 @@ pub struct BatchedMesh<V: BatchedVertex, U: BatchedUniform> {
 	draw_count: usize,
 }
 
-impl<V: BatchedVertex, U: BatchedUniform> BatchedMesh<V, U> {
+impl<V: VertexLayout, U: UniformLayout> BatchedMesh<V, U> {
 
 	pub fn new(device: &Device, max_vertices: usize, max_indices: usize) -> Result<Self> {
 

--- a/src/gl/fbuf.rs
+++ b/src/gl/fbuf.rs
@@ -42,10 +42,10 @@ impl Framebuffer {
 			ctx.bind_renderbuffer(glow::RENDERBUFFER, None);
 
 			let fbuf = Self {
-				ctx: ctx,
-				id: id,
-				tex: tex,
-				rbo: rbo,
+				ctx,
+				id,
+				tex,
+				rbo,
 			};
 
 			fbuf.bind();
@@ -66,7 +66,7 @@ impl Framebuffer {
 			);
 
 			if fbuf.ctx.check_framebuffer_status(glow::FRAMEBUFFER) != glow::FRAMEBUFFER_COMPLETE {
-				return Err(format!("failed to create framebuffer"));
+				return Err("failed to create framebuffer".to_string());
 			}
 
 			device.clear(Surface::Depth);

--- a/src/gl/ibuf.rs
+++ b/src/gl/ibuf.rs
@@ -23,8 +23,8 @@ impl IndexBuffer {
 			let id = ctx.create_buffer()?;
 
 			let buf = Self {
-				ctx: ctx,
-				id: id,
+				ctx,
+				id,
 			};
 
 			buf.bind();

--- a/src/gl/mesh.rs
+++ b/src/gl/mesh.rs
@@ -19,8 +19,8 @@ impl<V: VertexLayout, U: UniformLayout> Mesh<V, U> {
 		let ibuf = IndexBuffer::from(&device, &indices)?;
 
 		return Ok(Self {
-			vbuf: vbuf,
-			ibuf: ibuf,
+			vbuf,
+			ibuf,
 			count: indices.len(),
 			_uniform_layout: PhantomData,
 		});

--- a/src/gl/mod.rs
+++ b/src/gl/mod.rs
@@ -94,14 +94,14 @@ impl Device {
 
 			return match self.ctx.get_error() {
 				glow::NO_ERROR => Ok(()),
-				glow::INVALID_ENUM => Err(format!("opengl: invalid enum")),
-				glow::INVALID_VALUE => Err(format!("opengl: invalid value")),
-				glow::INVALID_OPERATION => Err(format!("opengl: invalid operation")),
-				glow::STACK_OVERFLOW => Err(format!("opengl: stack overflow")),
-				glow::STACK_UNDERFLOW => Err(format!("opengl: stack underflow")),
-				glow::OUT_OF_MEMORY => Err(format!("opengl: out of memory")),
-				glow::INVALID_FRAMEBUFFER_OPERATION => Err(format!("opengl: invalid framebuffer operation")),
-				_ => Err(format!("opengl: unknown error")),
+				glow::INVALID_ENUM => Err("opengl: invalid enum".to_string()),
+				glow::INVALID_VALUE => Err("opengl: invalid value".to_string()),
+				glow::INVALID_OPERATION => Err("opengl: invalid operation".to_string()),
+				glow::STACK_OVERFLOW => Err("opengl: stack overflow".to_string()),
+				glow::STACK_UNDERFLOW => Err("opengl: stack underflow".to_string()),
+				glow::OUT_OF_MEMORY => Err("opengl: out of memory".to_string()),
+				glow::INVALID_FRAMEBUFFER_OPERATION => Err("opengl: invalid framebuffer operation".to_string()),
+				_ => Err("opengl: unknown error".to_string()),
 			};
 
 		}

--- a/src/gl/pipeline.rs
+++ b/src/gl/pipeline.rs
@@ -86,9 +86,9 @@ impl<V: VertexLayout, U: UniformLayout> Pipeline<V, U> {
 			ctx.delete_shader(frag_id);
 
 			let program = Self {
-				ctx: ctx,
+				ctx,
 				attrs: V::attrs(),
-				program_id: program_id,
+				program_id,
 				_vertex_layout: PhantomData,
 				_uniform_layout: PhantomData,
 			};

--- a/src/gl/texture.rs
+++ b/src/gl/texture.rs
@@ -39,10 +39,10 @@ impl Texture2D {
 			let id = ctx.create_texture()?;
 
 			let tex = Self {
-				ctx: ctx,
-				id: id,
-				width: width,
-				height: height,
+				ctx,
+				id,
+				width,
+				height,
 			};
 
 			tex.bind();
@@ -254,10 +254,10 @@ impl CubemapTexture {
 			let id = ctx.create_texture()?;
 
 			let tex = Self {
-				ctx: ctx,
-				id: id,
-				width: width,
-				height: height,
+				ctx,
+				id,
+				width,
+				height,
 			};
 
 			tex.bind();

--- a/src/gl/uniform.rs
+++ b/src/gl/uniform.rs
@@ -16,7 +16,7 @@ impl IntoUniformValue for UniformValue {
 	}
 }
 
-pub trait UniformLayout: 'static {
+pub trait UniformLayout: Clone + PartialEq + 'static {
 	fn values(&self) -> UniformValues;
 	fn textures(&self) -> Vec<&dyn Texture>;
 }

--- a/src/gl/vbuf.rs
+++ b/src/gl/vbuf.rs
@@ -28,8 +28,8 @@ impl<V: VertexLayout> VertexBuffer<V> {
 			let id = ctx.create_buffer()?;
 
 			let buf = Self {
-				ctx: ctx,
-				id: id,
+				ctx,
+				id,
 				_layout: PhantomData,
 			};
 

--- a/src/gl/vbuf.rs
+++ b/src/gl/vbuf.rs
@@ -7,7 +7,7 @@ use glow::HasContext;
 use super::*;
 use crate::Result;
 
-pub trait VertexLayout {
+pub trait VertexLayout: Clone {
 	fn attrs() -> VertexAttrGroup;
 }
 

--- a/src/img.rs
+++ b/src/img.rs
@@ -28,15 +28,15 @@ impl Image {
 	pub fn from_raw(w: i32, h: i32, data: Vec<u8>) -> Result<Self> {
 
 		if data.len() != w as usize * h as usize * 4 {
-			return Err(format!("incorrect image size"));
+			return Err("incorrect image size".to_string());
 		}
 
 		if w <= 0 || h <= 0 {
-			return Err(format!("image size must be > 0"))
+			return Err("image size must be > 0".to_string())
 		}
 
 		return Ok(Self {
-			data: data,
+			data,
 			width: w,
 			height: h,
 		});
@@ -46,7 +46,7 @@ impl Image {
 	pub fn from_bytes(data: &[u8]) -> Result<Self> {
 
 		let img = image::load_from_memory(data)
-			.map_err(|_| format!("failed to parse img"))?
+			.map_err(|_| "failed to parse img".to_string())?
 			.to_rgba()
 			;
 

--- a/src/kit/particle.rs
+++ b/src/kit/particle.rs
@@ -97,7 +97,7 @@ impl ParticleSystem {
 			spawn_timer: timer,
 			particles: Vec::with_capacity(256),
 			paused: false,
-			conf: conf,
+			conf,
 		};
 
 	}
@@ -105,16 +105,14 @@ impl ParticleSystem {
 	pub fn update(&mut self, dt: Duration) {
 
 		if let Some(timer) = &mut self.spawn_timer {
-			if !self.paused {
-				if timer.tick(dt) {
-					let rate = rand_t(self.conf.rate);
-					if rate == 0.0 {
-						self.spawn_timer = None;
-					} else {
-						timer.reset_to_secs(1.0 / rate)
-					};
-					self.emit();
-				}
+			if !self.paused && timer.tick(dt) {
+				let rate = rand_t(self.conf.rate);
+				if rate == 0.0 {
+					self.spawn_timer = None;
+				} else {
+					timer.reset_to_secs(1.0 / rate)
+				};
+				self.emit();
 			}
 		} else {
 			let rate = rand_t(self.conf.rate);
@@ -184,9 +182,9 @@ impl ParticleSystem {
 					acc: rand_t(self.conf.acc),
 					vel: rand_t(self.conf.vel),
 					speed: rand_t(self.conf.speed),
-					color_start: color_start,
+					color_start,
 					color_end: self.conf.color_end,
-					size_start: size_start,
+					size_start,
 					size_end: rand_t(self.conf.size_end),
 					dead: false,
 				};

--- a/src/kit/sprite.rs
+++ b/src/kit/sprite.rs
@@ -23,7 +23,7 @@ impl Sprite {
 
 	pub fn from_tex(tex: gfx::Texture) -> Self {
 		return Self {
-			tex: tex,
+			tex,
 			frames: vec![quad!(0, 0, 1, 1)],
 			cur_frame: 0,
 			offset: vec2!(0),
@@ -106,9 +106,9 @@ impl Sprite {
 
 	pub fn add_anim(&mut self, name: &str, from: usize, to: usize, looping: bool) {
 		self.anims.insert(name.to_owned(), Anim {
-			from: from,
-			to: to,
-			looping: looping,
+			from,
+			to,
+			looping,
 		});
 	}
 

--- a/src/kit/textedit.rs
+++ b/src/kit/textedit.rs
@@ -86,7 +86,7 @@ impl Input {
 	}
 
 	fn clamp_cursor(&self, i: Col) -> Col {
-		return i.clamp(0, self.content.len() as Col);
+		return num_traits::clamp(i, 0, self.content.len() as Col);
 	}
 
 	pub fn move_to(&mut self, i: Col) {
@@ -491,7 +491,7 @@ impl TextArea {
 
 		}
 
-		return ln.clamp(1, self.lines.len() as Line);
+		return num_traits::clamp(ln, 1, self.lines.len() as Line);
 
 	}
 
@@ -627,8 +627,8 @@ impl TextArea {
 			if let Some(line) = self.get_line_at(start.line) {
 
 				let mut line = line.clone();
-				let start_col = (start.col - 1).clamp(0, line.len() as i32);
-				let end_col = end.col.clamp(0, line.len() as i32);
+				let start_col = num_traits::clamp((start.col - 1), 0, line.len() as i32);
+				let end_col = num_traits::clamp(end.col, 0, line.len() as i32);
 
 				self.push_undo();
 				line.replace_range(start_col as usize..end_col as usize, "");
@@ -770,7 +770,7 @@ impl TextArea {
 
 		if pos.col <= line.len() as Col + 1 {
 
-			let end = (pos.col - 2).clamp(0, line.len() as i32);
+			let end = num_traits::clamp((pos.col - 2), 0, line.len() as i32);
 
 			for (i, ch) in line[..end as usize].char_indices().rev() {
 

--- a/src/kit/textedit.rs
+++ b/src/kit/textedit.rs
@@ -65,7 +65,7 @@ impl Input {
 
 		return Self {
 			content: conf.init_content.clone(),
-			conf: conf,
+			conf,
 			cursor: 0,
 			undo_stack: vec![],
 			redo_stack: vec![],
@@ -367,7 +367,7 @@ impl TextArea {
 	pub fn with_conf(conf: Conf) -> Self {
 		return Self {
 			lines: conf.init_content.split('\n').map(String::from).collect(),
-			conf: conf,
+			conf,
 			cursor: CursorPos::default(),
 			undo_stack: vec![],
 			redo_stack: vec![],
@@ -595,15 +595,11 @@ impl TextArea {
 
 				}
 
-			} else {
-
-				if let Some(prev_pos) = self.prev_word_at(pos) {
-					return self.del_range((prev_pos, CursorPos {
-						col: pos.col - 1,
-						.. pos
-					}));
-				}
-
+			} else if let Some(prev_pos) = self.prev_word_at(pos) {
+				return self.del_range((prev_pos, CursorPos {
+					col: pos.col - 1,
+					.. pos
+				}));
 			}
 
 		}

--- a/src/kit/timer.rs
+++ b/src/kit/timer.rs
@@ -15,7 +15,7 @@ impl Timer {
 	pub fn new(time: Duration) -> Self {
 		return Self {
 			elapsed: Duration::from_secs_f32(0.0),
-			time: time,
+			time,
 			done: false,
 		}
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,6 @@
 #![feature(try_blocks)]
 #![feature(box_syntax)]
 #![feature(option_zip)]
-#![feature(trait_alias)]
 #![feature(const_int_pow)]
 #![feature(type_alias_impl_trait)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@
 #![allow(unused_parens)]
 #![allow(unused_variables)]
 #![allow(dead_code)]
+#![allow(clippy::needless_return)]
 
 #[macro_use]
 pub mod utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,13 +40,6 @@
 //!
 //! for more information checkout each indivisual docs
 
-#![feature(clamp)]
-#![feature(try_blocks)]
-#![feature(box_syntax)]
-#![feature(option_zip)]
-#![feature(const_int_pow)]
-#![feature(type_alias_impl_trait)]
-
 #![allow(unused_parens)]
 #![allow(unused_variables)]
 #![allow(dead_code)]

--- a/src/math/lerp.rs
+++ b/src/math/lerp.rs
@@ -2,12 +2,20 @@
 
 use std::ops::*;
 
-pub trait Lerpable =
+pub trait Lerpable:
 	Copy
-	+ Add<Output = Self>
-	+ Sub<Output = Self>
-	+ Mul<f32, Output = Self>
-	;
+	+ Add<Output=Self>
+	+ Sub<Output=Self>
+	+ Mul<f32, Output=Self>
+	where Self: Sized
+{}
+
+impl<T> Lerpable for T
+	where T: Copy
+		+ Add<Output=T>
+		+ Sub<Output=T>
+		+ Mul<f32, Output=T>
+{}
 
 pub trait Lerping: Lerpable {
 

--- a/src/math/lerp.rs
+++ b/src/math/lerp.rs
@@ -20,12 +20,12 @@ impl<T> Lerpable for T
 pub trait Lerping: Lerpable {
 
 	fn lerp(self, to: Self, amount: f32) -> Self {
-		return self + (to - self) * amount.clamp(0.0, 1.0);
+		return self + (to - self) * num_traits::clamp(amount, 0.0, 1.0);
 	}
 
 	fn smooth(self, to: Self, amount: f32) -> Self {
 
-		let t = amount.clamp(0.0, 1.0);
+		let t = num_traits::clamp(amount, 0.0, 1.0);
 		let m = t * t * (3.0 - 2.0 * t);
 
 		return self + (to - self) * m;

--- a/src/math/map.rs
+++ b/src/math/map.rs
@@ -2,22 +2,18 @@
 
 use std::ops::*;
 
-pub trait Mappable =
-	Copy
-	+ Add<Self, Output = Self>
-	+ Sub<Self, Output = Self>
-	+ Mul<Self, Output = Self>
-	+ Div<Self, Output = Self>
-	;
+pub trait Mapping: Sized + Copy
+	+ Add<Output=Self>
+	+ Sub<Output=Self>
+	+ Mul<Output=Self>
+	+ Div<Output=Self>
+{
 
-pub trait Mapping<T: Mappable + Mul<Self, Output = T>>: Mappable {
-
-	fn map(self, a1: Self, a2: Self, b1: T, b2: T) -> T {
+	fn map(self, a1: Self, a2: Self, b1: Self, b2: Self) -> Self {
 		let r: Self = (self - a1) / (a2 - a1);
 		return b1 + (b2 - b1) * r;
 	}
 
 }
 
-impl<T: Mappable, F: Mappable + Mul<T, Output = F>> Mapping<F> for T {}
-
+impl Mapping for f32 {}

--- a/src/math/mat.rs
+++ b/src/math/mat.rs
@@ -15,7 +15,7 @@ impl Mat4 {
 
 	pub fn new(m: [f32; 16]) -> Self {
 		return Self {
-			m: m,
+			m,
 		};
 	}
 

--- a/src/math/rand.rs
+++ b/src/math/rand.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 
-use random;
+
 use random::seq::SliceRandom;
 use random::SeedableRng;
 

--- a/src/math/vec.rs
+++ b/src/math/vec.rs
@@ -227,8 +227,8 @@ impl Vec2 {
 
 	pub fn clamp(self, low: Self, hi: Self) -> Self {
 		return vec2!(
-			self.x.clamp(low.x, hi.x),
-			self.y.clamp(low.y, hi.y),
+			num_traits::clamp(self.x, low.x, hi.x),
+			num_traits::clamp(self.y, low.y, hi.y),
 		);
 	}
 
@@ -274,9 +274,9 @@ impl Vec3 {
 
 	pub fn clamp(self, low: Self, hi: Self) -> Self {
 		return vec3!(
-			self.x.clamp(low.x, hi.x),
-			self.y.clamp(low.y, hi.y),
-			self.z.clamp(low.z, hi.z),
+			num_traits::clamp(self.x, low.x, hi.x),
+			num_traits::clamp(self.y, low.y, hi.y),
+			num_traits::clamp(self.z, low.z, hi.z),
 		);
 	}
 
@@ -333,10 +333,10 @@ impl Color {
 
 	pub fn clamp(self, c1: Self, c2: Self) -> Self {
 		return rgba!(
-			self.r.clamp(c1.r, c2.r),
-			self.g.clamp(c1.g, c2.g),
-			self.b.clamp(c1.b, c2.b),
-			self.a.clamp(c1.a, c2.a),
+			num_traits::clamp(self.r, c1.r, c2.r),
+			num_traits::clamp(self.g, c1.g, c2.g),
+			num_traits::clamp(self.b, c1.b, c2.b),
+			num_traits::clamp(self.a, c1.a, c2.a),
 		);
 	}
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -29,7 +29,7 @@ impl<T: Send + 'static> TaskQueue<T> {
 		return Self {
 			queue: VecDeque::new(),
 			active: vec![],
-			max: max,
+			max,
 			completed: 0,
 			total: 0,
 		};
@@ -136,7 +136,7 @@ impl<T: Send + 'static> Task<T> {
 				.name(String::from("dirty_task"))
 				.spawn(move || {
 				tx.send(action()).expect("thread failure");
-			}).map_err(|_| format!("failed to spawn task thread"))?;
+			}).map_err(|_| "failed to spawn task thread".to_string())?;
 
 			self.rx = Some(rx);
 			self.phase = TaskPhase::Working;

--- a/src/task.rs
+++ b/src/task.rs
@@ -106,7 +106,7 @@ impl<T: TaskItem> Task<T> {
 
 	pub fn new(f: impl FnOnce() -> T + TaskItem) -> Self {
 		return Self {
-			action: Some(box f),
+			action: Some(Box::new(f)),
 			rx: None,
 			phase: TaskPhase::StandBy,
 		};

--- a/src/task.rs
+++ b/src/task.rs
@@ -6,8 +6,8 @@ use std::collections::VecDeque;
 use std::sync::mpsc;
 use std::thread;
 
-pub trait TaskItem = Send + 'static;
-pub trait TaskAction<T: TaskItem> = FnOnce() -> T + Send + 'static;
+pub type TaskItem = Send + 'static;
+pub type TaskAction<T: TaskItem> = FnOnce() -> T + Send + 'static;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum TaskPhase {

--- a/src/ui/button.rs
+++ b/src/ui/button.rs
@@ -12,7 +12,7 @@ pub struct Button {
 impl Button {
 	pub fn new(text: &'static str) -> Self {
 		return Self {
-			text: text,
+			text,
 			clicked: false,
 			pressed: false,
 			hovering: false,
@@ -57,7 +57,7 @@ impl Widget for Button {
 
 		let theme = &wctx.theme;
 
-		let ptext = shapes::text(&format!("{}", self.text))
+		let ptext = shapes::text(&self.text.to_string())
 			.size(theme.font_size)
 			.color(theme.title_color)
 			.align(gfx::Origin::TopLeft)

--- a/src/ui/checkbox.rs
+++ b/src/ui/checkbox.rs
@@ -11,8 +11,8 @@ pub struct CheckBox {
 impl CheckBox {
 	pub fn new(prompt: &'static str, checked: bool,) -> Self {
 		return Self {
-			prompt: prompt,
-			checked: checked,
+			prompt,
+			checked,
 			hovering: false,
 		};
 	}
@@ -48,7 +48,7 @@ impl Widget for CheckBox {
 		let size = theme.font_size + 6.0;
 		let sep = 12.0;
 
-		let ptext = shapes::text(&format!("{}", self.prompt))
+		let ptext = shapes::text(&self.prompt.to_string())
 			.size(theme.font_size)
 			.color(theme.title_color)
 			.align(gfx::Origin::TopLeft)

--- a/src/ui/checkbox.rs
+++ b/src/ui/checkbox.rs
@@ -26,7 +26,7 @@ impl Widget for CheckBox {
 	fn event(&mut self, d: &mut Ctx, e: &input::Event) {
 
 		use input::Event::*;
-		use input::Key;
+		// use input::Key;
 		use input::Mouse;
 
 		match e {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -40,7 +40,7 @@ impl UI {
 
 		use input::Event::*;
 		use input::Mouse;
-		use input::Key;
+		// use input::Key;
 		use geom::*;
 
 		let mpos = d.window.mouse_pos();

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -124,8 +124,8 @@ impl UI {
 	) -> Result<()> {
 
 		let window = self.windows.entry(title).or_insert(Window {
-			title: title,
-			pos: pos,
+			title,
+			pos,
 			width: w,
 			height: h,
 			widgets: hmap![],
@@ -174,8 +174,8 @@ impl UI {
 
 		let window_ctx = WindowCtx {
 			theme: &self.theme,
-			width: width,
-			offset: offset,
+			width,
+			offset,
 		};
 
 		let dwindow = &mut d.window;
@@ -190,7 +190,7 @@ impl UI {
 				window: dwindow,
 				audio: daudio,
 				app: dapp,
-				gfx: gfx,
+				gfx,
 			};
 
 			let mut wman = WidgetManager {
@@ -250,7 +250,7 @@ impl<'a> WidgetManager<'a> {
 		let wctx = WidgetCtx {
 			theme: self.ctx.theme,
 			width: self.ctx.width,
-			offset: offset,
+			offset,
 			mouse_pos: d.window.mouse_pos() - offset,
 		};
 
@@ -282,14 +282,14 @@ impl<'a> WidgetManager<'a> {
 			.as_mut()
 			.as_any_mut()
 			.downcast_mut::<W>()
-			.ok_or(format!("failed to cast widget types"))?;
+			.ok_or("failed to cast widget types".to_string())?;
 
 		let offset = self.ctx.offset + vec2!(0, -self.cur_y);
 
 		let wctx = WidgetCtx {
 			theme: self.ctx.theme,
 			width: self.ctx.width,
-			offset: offset,
+			offset,
 			mouse_pos: d.window.mouse_pos() - offset,
 		};
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -279,7 +279,7 @@ impl<'a> WidgetManager<'a> {
 
 		let w = self.widgets
 			.entry(id)
-			.or_insert_with(|| box w())
+			.or_insert_with(|| Box::new(w()))
 			.as_mut()
 			.as_any_mut()
 			.downcast_mut::<W>()

--- a/src/ui/select.rs
+++ b/src/ui/select.rs
@@ -33,7 +33,7 @@ impl Widget for Select {
 	fn event(&mut self, d: &mut Ctx, e: &input::Event) {
 
 		use input::Event::*;
-		use input::Key;
+		// use input::Key;
 		use input::Mouse;
 
 		let kmods = d.window.key_mods();

--- a/src/ui/select.rs
+++ b/src/ui/select.rs
@@ -17,7 +17,7 @@ enum State {
 impl Select {
 	pub fn new(prompt: &'static str, options: &[&str], i: usize) -> Self {
 		return Self {
-			prompt: prompt,
+			prompt,
 			options: options.iter().map(|s| s.to_string()).collect(),
 			selected: i,
 			state: State::Idle(false),

--- a/src/ui/slider.rs
+++ b/src/ui/slider.rs
@@ -100,7 +100,7 @@ impl Widget for Slider {
 			let delta_x = wctx.mouse_pos.x - prev_x;
 
 			self.val += (delta_x / wctx.width) * (self.max - self.min);
-			self.val = self.val.clamp(self.min, self.max);
+			self.val = num_traits::clamp(self.val, self.min, self.max);
 
 			self.draggin = Some(wctx.mouse_pos.x)
 

--- a/src/ui/slider.rs
+++ b/src/ui/slider.rs
@@ -1,7 +1,6 @@
 // wengwengweng
 
 use super::*;
-use std::ops::*;
 
 pub struct Slider {
 	prompt: &'static str,
@@ -33,7 +32,7 @@ impl Widget for Slider {
 	fn event(&mut self, d: &mut Ctx, e: &input::Event) {
 
 		use input::Event::*;
-		use input::Key;
+		// use input::Key;
 		use input::Mouse;
 
 		match e {
@@ -60,7 +59,7 @@ impl Widget for Slider {
 
 	fn draw(&mut self, gfx: &mut gfx::Gfx, wctx: &WidgetCtx) -> Result<f32> {
 
-		use input::Mouse;
+		// use input::Mouse;
 		use geom::*;
 
 		let mut y = 0.0;

--- a/src/ui/slider.rs
+++ b/src/ui/slider.rs
@@ -15,9 +15,9 @@ impl Slider {
 	pub fn new(p: &'static str, val: f32, min: f32, max: f32) -> Self {
 		return Self {
 			prompt: p,
-			val: val,
-			min: min,
-			max: max,
+			val,
+			min,
+			max,
 			draggin: None,
 			hovering: false,
 		};

--- a/src/ui/tinput.rs
+++ b/src/ui/tinput.rs
@@ -14,7 +14,7 @@ impl Input {
 	pub fn new(prompt: &'static str,) -> Self {
 		return Self {
 			buf: textedit::Input::new(),
-			prompt: prompt,
+			prompt,
 			focused: false,
 			hovering: false,
 		};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,6 +16,7 @@ macro_rules! export {
 macro_rules! import {
 	($name:ident) => {
 		mod $name;
+		#[allow(unused)]
 		use $name::*;
 	}
 }

--- a/src/window/native.rs
+++ b/src/window/native.rs
@@ -68,9 +68,9 @@ impl Window {
 		let windowed_ctx = unsafe {
 			ctx_builder
 				.build_windowed(window_builder, &event_loop)
-				.map_err(|_| format!("failed to build window"))?
+				.map_err(|_| "failed to build window".to_string())?
 				.make_current()
-				.map_err(|_| format!("failed to make opengl context"))?
+				.map_err(|_| "failed to make opengl context".to_string())?
 		};
 
 		if conf.cursor_hidden {
@@ -83,7 +83,7 @@ impl Window {
 
 		return Ok(Self {
 			event_loop: Some(event_loop),
-			windowed_ctx: windowed_ctx,
+			windowed_ctx,
 			pressed_keys: hset![],
 			pressed_mouse: hset![],
 			pressed_gamepad_buttons: hmap![],
@@ -97,7 +97,7 @@ impl Window {
 			title: conf.title.to_string(),
 			quit: false,
 			gamepad_ctx: gilrs::Gilrs::new()
-				.map_err(|_| format!("failed to create gamepad context"))?,
+				.map_err(|_| "failed to create gamepad context".to_string())?,
 		});
 
 	}
@@ -117,7 +117,7 @@ impl Window {
 	pub(crate) fn swap(&self) -> Result<()> {
 		self.windowed_ctx
 			.swap_buffers()
-			.map_err(|_| format!("failed to swap buffer"))?;
+			.map_err(|_| "failed to swap buffer".to_string())?;
 		return Ok(());
 	}
 
@@ -171,7 +171,7 @@ impl Window {
 		self.windowed_ctx
 			.window()
 			.set_cursor_position(g_mpos)
-			.map_err(|_| format!("failed to set mouse position"))?
+			.map_err(|_| "failed to set mouse position".to_string())?
 			;
 
 		self.mouse_pos = mpos;

--- a/src/window/native.rs
+++ b/src/window/native.rs
@@ -305,7 +305,7 @@ impl Window {
 
 			*flow = ControlFlow::Poll;
 
-			let res: Result<()> = try {
+			let res: Result<()> = || -> Result<()> {
 
 				use glutin::event::WindowEvent as WEvent;
 				use glutin::event::DeviceEvent as DEvent;
@@ -599,7 +599,8 @@ impl Window {
 					handle(&mut self, WindowEvent::Input(e))?;
 				}
 
-			};
+				Ok(())
+			}();
 
 			if let Err(err) = res {
 				elog!("{}", err);

--- a/src/window/native.rs
+++ b/src/window/native.rs
@@ -78,7 +78,7 @@ impl Window {
 		}
 
 		if conf.cursor_locked {
-			windowed_ctx.window().set_cursor_grab(true);
+			windowed_ctx.window().set_cursor_grab(true).expect("cannot set cursor grab");
 		}
 
 		return Ok(Self {
@@ -213,7 +213,7 @@ impl Window {
 
 	/// set cursor locked
 	pub fn set_cursor_locked(&mut self, b: bool) {
-		self.windowed_ctx.window().set_cursor_grab(b);
+		self.windowed_ctx.window().set_cursor_grab(b).expect("cannot set cursor grab");
 		self.cursor_locked = b;
 	}
 

--- a/src/window/web.rs
+++ b/src/window/web.rs
@@ -260,9 +260,9 @@ impl Window {
 
 				let web_events_c = web_events.clone();
 
-				let handler = Closure::wrap(box (move |e: $ty| {
+				let handler = Closure::wrap(Box::new((move |e: $ty| {
 					web_events_c.borrow_mut().push(WebEvent::$t(e));
-				}) as Box<dyn FnMut(_)>);
+				})) as Box<dyn FnMut(_)>);
 
 				self.$root
 					.add_event_listener_with_callback($name, handler.as_ref().unchecked_ref())
@@ -290,7 +290,7 @@ impl Window {
 
 		render_loop.run(move |running: &mut bool| {
 
-			let res: Result<()> = try {
+			let res = || -> Result<()> {
 
 				let mut events = vec![];
 
@@ -355,8 +355,8 @@ impl Window {
 				}
 
 				handle(&mut self, WindowEvent::Frame)?;
-
-			};
+				Ok(())
+			}();
 
 			if let Err(err) = res {
 				elog!("{}", err);


### PR DESCRIPTION
This PR does the following:
1. add rust Github Action CI build pipeline
2. allow DIRTY to be compiled on the latest stable rust toolchain
3. general code clean up `CLIPPY_ARGS="-Aclippy::needless_return" cargo +nightly clippy --fix -Z unstable-options`
4. add `squiggly_line.rs` example